### PR TITLE
chore(examples): correct diagram paths

### DIFF
--- a/modeler/modeler.html
+++ b/modeler/modeler.html
@@ -52,7 +52,7 @@
 
     <script>
 
-      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/4843ea28/starter/diagram.dmn';
+      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/a71e16/starter/diagram.dmn';
 
       var CLASS_NAMES = {
         drd: 'dmn-icon-lasso-tool',
@@ -62,8 +62,6 @@
 
       var $container = $('.editor-container');
       var $tabs = $('.editor-tabs');
-
-      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/4843ea28/starter/diagram.dmn';
 
       // modeler instance
       var dmnModeler = new DmnJS({

--- a/starter/modeler.html
+++ b/starter/modeler.html
@@ -41,7 +41,7 @@
 
     <script>
 
-      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/4843ea28/starter/diagram.dmn';
+      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/a71e16/starter/diagram.dmn';
 
       // modeler instance
       var dmnModeler = new DmnJS({

--- a/starter/viewer.html
+++ b/starter/viewer.html
@@ -30,7 +30,7 @@
 
     <script>
 
-      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/4843ea28/starter/diagram.dmn';
+      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/a71e16/starter/diagram.dmn';
 
       // viewer instance
       var dmnViewer = new DmnJS({


### PR DESCRIPTION
I do not see any specific reason while we use the diagram for a specific commit (cf. [previous version](https://cdn.staticaly.com/gh/bpmn-io/dmn-js-examples/4843ea28/starter/diagram.dmn)). So let's use the `master` version for the examples.