### PR TITLE
fix(modeler): move script import to page bottom

### DIFF
--- a/modeler/modeler.html
+++ b/modeler/modeler.html
@@ -13,12 +13,6 @@
     <link rel="stylesheet" href="https://unpkg.com/dmn-js@15.1.0/dist/assets/dmn-js-literal-expression.css">
     <link rel="stylesheet" href="https://unpkg.com/dmn-js@15.1.0/dist/assets/dmn-font/css/dmn.css">
 
-    <!-- modeler distro -->
-    <script src="https://unpkg.com/dmn-js@15.1.0/dist/dmn-modeler.development.js"></script>
-
-    <!-- needed for this example only -->
-    <script src="https://unpkg.com/jquery@3.3.1/dist/jquery.js"></script>
-
     <!-- example styles -->
     <link rel="stylesheet" href="style.css">
 
@@ -49,6 +43,12 @@
     </div>
 
     <button id="save-button">print to console</button>
+
+    <!-- modeler distro -->
+    <script src="https://unpkg.com/dmn-js@15.1.0/dist/dmn-modeler.development.js"></script>
+
+    <!-- needed for this example only -->
+    <script src="https://unpkg.com/jquery@3.3.1/dist/jquery.js"></script>
 
     <script>
 


### PR DESCRIPTION
This ensures the example runs.

Scripts shall always be loaded at the page bottom or certain elements (`document.body`) are not yet available.